### PR TITLE
Fix CSS lint and infinite build path error

### DIFF
--- a/src/dotnetCloudantWebstarter/project.json
+++ b/src/dotnetCloudantWebstarter/project.json
@@ -1,7 +1,8 @@
 {
     "buildOptions": {
         "copyToOutput": {
-            "include": [ "wwwroot", "**.cshtml" ]
+            "include": [ "wwwroot", "**.cshtml" ],
+            "exclude": [ "bin" ]
         },
         "debugType": "portable",
         "emitEntryPoint": true,
@@ -36,8 +37,8 @@
     },
 
     "publishOptions": {
-        "include": [ "wwwroot" ],
-        "exclude": [ "**.user", "**.vspscc" ]
+        "include": [ "wwwroot", "**.cshtml" ],
+        "exclude": [ "**.user", "**.vspscc", "bin" ]
     },
 
     "scripts": { },

--- a/src/dotnetCloudantWebstarter/wwwroot/css/style.css
+++ b/src/dotnetCloudantWebstarter/wwwroot/css/style.css
@@ -74,19 +74,7 @@ header,footer {
 	margin: 0 auto;
 }
 
-/* foreground color */
-.title,.tips {
-	
-}
-
-td {
-	
-}
 /* background color */
-table {
-	
-}
-
 .leftHalf {
 	float: left;
 	background-color: #26343f;
@@ -162,7 +150,7 @@ button {
 	top: 0px;
 	background: none;
 	border: none;
-	cursor: pointer;s
+	cursor: pointer;
 }
 
 .addBtn {
@@ -173,11 +161,6 @@ button {
 	border: none;
 	cursor: pointer;
 }
-
-.detailBtn img,.addBtn img {
-	
-}
-
 
 /* dynamic effect */
 .records tr:hover .deleteBtn {


### PR DESCRIPTION
Including glob patterns with wildcards like "**.cshtml" will copy files from the bin subdirectory into the output (also the bin subdirectory) causing the path to grow every time the project is rebuilt when working locally.  Eventually this causes Visual Studio to be unable to run/debug the project.  Solution is to explicitly exclude the bin subfolder from being copied.  This commit also fixes some css lint.
