### PR TITLE
Increase memory limit to 512MB

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,7 +6,7 @@ declared-services:
 applications:
 - name: sample-aspnetcore-cloudant
   random-route: true
-  memory: 256M
+  memory: 512M
   services:
   - sample-aspnetcore-cloudant-cloudantNoSQLDB
   


### PR DESCRIPTION
Increasing the memory limit to 512MB to avoid intermittent issues that some users are experiencing.
