### PR TITLE
Update for .NET Core 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Sept 21, 2016
+- Update sample to use .NET Core 1.0.1
+
 ## May 16, 2016
 - Update sample to use Dotnet CLI
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This application demonstrates how to use the Bluemix Cloudant NoSQL DB Service i
 4. Copy the value for the VCAP_SERVICES envirionment variable from the application running in Bluemix and paste it in the config.json file
 5. Run `dotnet restore`
 6. Run `dotnet run`
-7. Access the running app in a browser at http://localhost:5004
+7. Access the running app in a browser at http://localhost:5000
 
 [Getting Started]: http://docs.asp.net/en/latest/getting-started/index.html
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "projects": [ "src" ],
     "sdk": {
-        "version": "1.0.0-preview2-003121"
+        "version": "1.0.0-preview2-003131"
     }
 }

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 declared-services: 
   sample-aspnetcore-cloudant-cloudantNoSQLDB:
     label: cloudantNoSQLDB 
-    plan: Shared 
+    plan: Lite 
 applications:
 - name: sample-aspnetcore-cloudant
   random-route: true

--- a/src/dotnetCloudantWebstarter/project.json
+++ b/src/dotnetCloudantWebstarter/project.json
@@ -10,18 +10,18 @@
     },
 
     "dependencies": {
-        "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+        "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
         "Microsoft.AspNetCore.Diagnostics": "1.0.0",
         "Microsoft.Extensions.Configuration.CommandLine": "1.0.0",
         "Microsoft.Extensions.Configuration.Json": "1.0.0",
-        "Microsoft.AspNetCore.Mvc": "1.0.0",
+        "Microsoft.AspNetCore.Mvc": "1.0.1",
         "Microsoft.AspNetCore.StaticFiles": "1.0.0",
         "Microsoft.Extensions.Logging.Console": "1.0.0",
         "Microsoft.AspNet.WebApi.Client": "5.2.3",
         "Newtonsoft.Json": "9.0.1",
         "Microsoft.NETCore.App": {
             "type": "platform",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "include": "all"
         },
         "System.Runtime.Serialization.Xml": "4.1.1"
@@ -44,5 +44,5 @@
 
     "scripts": { },
 
-    "version": "1.0.0"
+    "version": "1.0.1"
 }


### PR DESCRIPTION
- Update app for .NET Core 1.0.1
- Switch to Cloudant Lite plan now that Shared plan is deprecated
